### PR TITLE
docs: fix readme typo on route name

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Retorno:
 }
 ```
 
-### `GET /v1/cpf`
+### `GET /v1/status`
 
 Retorna informações de status do servidor.
 


### PR DESCRIPTION
The GET /v1/status route description had it's
header (h3) written wrongly.